### PR TITLE
Disable the FileName cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -119,3 +119,6 @@ RSpec/LetSetup:
 
 Security/YAMLLoad:
   Enabled: false
+
+Naming/FileName:
+  Enabled: false


### PR DESCRIPTION
This PR disables the FileName cop and resolves the last warning on the repo.