### PR TITLE
Explicitly set gems to a specific version and bumped gem version

### DIFF
--- a/hint-rubocop_style.gemspec
+++ b/hint-rubocop_style.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r( ^exe/ )) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.49'
-  spec.add_dependency 'rubocop-rspec', '~> 1.15'
+  spec.add_dependency 'rubocop', '0.49.1'
+  spec.add_dependency 'rubocop-rspec', '1.15.1'
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/hint/rubocop_style/version.rb
+++ b/lib/hint/rubocop_style/version.rb
@@ -1,5 +1,5 @@
 module Hint
   module RubocopStyle
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end


### PR DESCRIPTION
This PR fixes an issue with changes to rubocop namespacing and sets the dependency gems to a specific version.