### PR TITLE
Relax rubocop-rspec dependency

### DIFF
--- a/hint-rubocop_style.gemspec
+++ b/hint-rubocop_style.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '>= 0.50.0'
-  spec.add_dependency 'rubocop-rspec', '1.17.0'
+  spec.add_dependency 'rubocop-rspec', '~> 1.17.0'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Rubocop 0.50.0 has issues with Rubocop-rspec < 1.20, which is a problem
when it's locked down to 1.17.0.