### PR TITLE
Align hash values

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -24,6 +24,11 @@ Style/PercentLiteralDelimiters:
     '%w': '()'
     '%W': '()'
 
+# Align hash values
+Layout/AlignHash:
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table
+
 # Allow empty lines around class body
 Layout/EmptyLinesAroundClassBody:
   Enabled: false


### PR DESCRIPTION
Would like to suggest making this setting a default. We use it on the main project I am on and it's really nice IMO.

Enforces making this:
```
my_hash = {
  balance: 5.23,
  name: 'John Doe',
  user_class: 'InternalUser'
}
```

Into this:
```
my_hash = {
  balance:    5.23,
  name:       'John Doe',
  user_class: 'InternalUser'
}
```

