### PR TITLE
Add rubocop-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ AllCops:
   TargetRubyVersion: PROJECT_RUBY_VERSION
   TargetRailsVersion: PROJECT_RAILS_VERSION
   DisplayCopNames: true
-  Include:
-    - '**/Rakefile'
-    - '**/config.ru'
   Exclude:
     - 'bin/**/*'
     - 'config/**/*'

--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,7 @@
 # adding Rubocop to a project run rubocop --auto-gen-config then uncomment line below
 # inherit_from: .rubocop_todo.yml
 require: rubocop-rspec
+require: rubocop-rails
 
 Rails:
   Enabled: true

--- a/default.yml
+++ b/default.yml
@@ -2,6 +2,7 @@
 # inherit_from: .rubocop_todo.yml
 require: rubocop-rspec
 require: rubocop-rails
+require: rubocop-performance
 
 Rails:
   Enabled: true

--- a/hint-rubocop_style.gemspec
+++ b/hint-rubocop_style.gemspec
@@ -3,14 +3,15 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hint/rubocop_style/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'hint-rubocop_style'
-  spec.version       = Hint::RubocopStyle::VERSION
-  spec.authors       = ['Hint']
-  spec.email         = ['tech@hint.io']
+  spec.name                  = 'hint-rubocop_style'
+  spec.version               = Hint::RubocopStyle::VERSION
+  spec.required_ruby_version = '>= 2.3.0'
+  spec.authors               = ['Hint']
+  spec.email                 = ['tech@hint.io']
 
-  spec.summary       = 'Hint shared Rubocop style guide'
-  spec.homepage      = 'https://github.com/hintmedia/hint-rubocop_style'
-  spec.license       = 'MIT'
+  spec.summary               = 'Hint shared Rubocop style guide'
+  spec.homepage              = 'https://github.com/hintmedia/hint-rubocop_style'
+  spec.license               = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -28,8 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r( ^exe/ )) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '>= 0.50.0'
-  spec.add_dependency 'rubocop-rspec', '>= 1.17.0'
+  spec.add_dependency 'rubocop', '>= 0.70.0'
+  spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
+  spec.add_dependency 'rubocop-rails', '>= 2.0.0'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/hint-rubocop_style.gemspec
+++ b/hint-rubocop_style.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '>= 0.70.0'
   spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
   spec.add_dependency 'rubocop-rails', '>= 2.0.0'
+  spec.add_dependency 'rubocop-performance', '>= 1.3.0'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/hint/rubocop_style/version.rb
+++ b/lib/hint/rubocop_style/version.rb
@@ -1,5 +1,5 @@
 module Hint
   module RubocopStyle
-    VERSION = '0.2.7'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end


### PR DESCRIPTION
This PR adds `rubocop-rails`, bumps minimum gem versions, adds a minimum Ruby version, and bumps the gem a minor version. The minimum version changes/addition are to match the requirements on the Rubocop gems. 