### PR TITLE
Disable RSpec/NestedGroups

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -101,6 +101,9 @@ RSpec/MessageExpectation:
 
 RSpec/LetSetup:
   Enabled: false
+  
+RSpec/NestedGroups:
+  Enabled: false
 
 Security/YAMLLoad:
   Enabled: false

--- a/lib/hint/rubocop_style/version.rb
+++ b/lib/hint/rubocop_style/version.rb
@@ -1,5 +1,5 @@
 module Hint
   module RubocopStyle
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end


### PR DESCRIPTION
I dislike this cop as I feel there are times that deeply nested contexts are the best way to approach a spec.

I think we generally ignore this cop, so disabling it is just making it official. :smile: