### PR TITLE
Revert "Upgrade bundler version dev dependency"

### DIFF
--- a/hint-rubocop_style.gemspec
+++ b/hint-rubocop_style.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
   spec.add_dependency 'rubocop-rails', '>= 2.0.0'
   spec.add_dependency 'rubocop-performance', '>= 1.3.0'
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
I have regret. Upgrading bundler has caused issues for me, I'd like to revert it.