### PR TITLE
Rename AlignHash to HashAlignment

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,6 @@
 # adding Rubocop to a project run rubocop --auto-gen-config then uncomment line below
 # inherit_from: .rubocop_todo.yml
-require: 
+require:
   - rubocop-rspec
   - rubocop-rails
   - rubocop-performance
@@ -21,7 +21,7 @@ Style/PercentLiteralDelimiters:
     '%W': '()'
 
 # Align hash values
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
 
@@ -101,7 +101,7 @@ RSpec/MessageExpectation:
 
 RSpec/LetSetup:
   Enabled: false
-  
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/hint-rubocop_style.gemspec
+++ b/hint-rubocop_style.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r( ^exe/ )) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '>= 0.70.0'
+  spec.add_dependency 'rubocop', '>= 0.77.0'
   spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
   spec.add_dependency 'rubocop-rails', '>= 2.0.0'
   spec.add_dependency 'rubocop-performance', '>= 1.3.0'


### PR DESCRIPTION
An error message began with rubocop 0.77.0.
https://github.com/rubocop-hq/rubocop/commit/7ab80f9e1d262ff34fe4a1ea1a752a22bec26310