### PR TITLE
Exclude specs and rake files from BlockLength

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -50,6 +50,12 @@ Layout/EmptyLinesAroundBlockBody:
 Layout/LineLength:
   Max: 100
 
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+
 Metrics/ModuleLength:
   Max: 200
 

--- a/lib/hint/rubocop_style/version.rb
+++ b/lib/hint/rubocop_style/version.rb
@@ -1,5 +1,5 @@
 module Hint
   module RubocopStyle
-    VERSION = '0.3.5'.freeze
+    VERSION = '0.3.6'.freeze
   end
 end


### PR DESCRIPTION
These files contain very long blocks by design.
Bump version to 0.3.6.